### PR TITLE
Add Vector2, Vector3 and Vector4 types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,6 +162,16 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "nalgebra"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "num 0.1.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "num"
 version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -306,6 +316,7 @@ dependencies = [
 name = "open_aoe_types"
 version = "0.1.0"
 dependencies = [
+ "nalgebra 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.21.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/crates/types/Cargo.toml
+++ b/crates/types/Cargo.toml
@@ -10,3 +10,4 @@ authors = ["Kevin Fuller <angered.ghandi@gmail.com>"]
 
 [dependencies]
 sdl2 = "0.21"
+nalgebra = "0.8.2"

--- a/crates/types/src/lib.rs
+++ b/crates/types/src/lib.rs
@@ -22,9 +22,11 @@
 //
 
 extern crate sdl2;
+extern crate nalgebra;
 
 mod rect;
 mod point;
 
 pub use point::Point;
 pub use rect::Rect;
+pub use nalgebra::{Vector2, Vector3, Vector4};

--- a/src/ecs/component/transform_component.rs
+++ b/src/ecs/component/transform_component.rs
@@ -20,14 +20,12 @@
 // SOFTWARE.
 
 use specs;
+use types::Vector3;
 
 #[derive(Clone, Debug)]
 pub struct TransformComponent {
-    // TODO: Move to a vector type
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
-    pub rotation: f32,
+    pub position: Vector3<f32>,
+    pub rotation: f32
 }
 
 impl specs::Component for TransformComponent {
@@ -37,10 +35,8 @@ impl specs::Component for TransformComponent {
 impl TransformComponent {
     pub fn new(x: f32, y: f32, z: f32, rotation: f32) -> TransformComponent {
         TransformComponent {
-            x: x,
-            y: y,
-            z: z,
-            rotation: rotation,
+            position: Vector3::new(x, y, z),
+            rotation: rotation
         }
     }
 }

--- a/src/ecs/component/velocity_component.rs
+++ b/src/ecs/component/velocity_component.rs
@@ -20,13 +20,11 @@
 // SOFTWARE.
 
 use specs;
+use types::Vector3;
 
 #[derive(Clone, Debug)]
 pub struct VelocityComponent {
-    // TODO: Move to a vector type
-    pub x: f32,
-    pub y: f32,
-    pub z: f32,
+    pub velocity: Vector3<f32>
 }
 
 impl specs::Component for VelocityComponent {
@@ -36,9 +34,7 @@ impl specs::Component for VelocityComponent {
 impl VelocityComponent {
     pub fn new() -> VelocityComponent {
         VelocityComponent {
-            x: 0f32,
-            y: 0f32,
-            z: 0f32,
+            velocity: Vector3::new(0f32, 0f32, 0f32)
         }
     }
 }

--- a/src/ecs/render_system/unit_render_system.rs
+++ b/src/ecs/render_system/unit_render_system.rs
@@ -77,8 +77,8 @@ impl<'a> UnitRenderSystem<'a> {
 
     fn project(&self, transform: &TransformComponent) -> Point {
         let (tile_half_width, tile_half_height) = self.tile_half_sizes();
-        Point::new(((transform.y + transform.x) * tile_half_width) as i32,
-                   ((transform.y - transform.x - transform.z) * tile_half_height) as i32)
+        Point::new(((transform.position.y + transform.position.x) * tile_half_width) as i32,
+                   ((transform.position.y - transform.position.x - transform.position.z) * tile_half_height) as i32)
     }
 
     #[inline]

--- a/src/ecs/resource.rs
+++ b/src/ecs/resource.rs
@@ -20,18 +20,9 @@
 // SOFTWARE.
 
 use media::Key;
+use types::Vector2;
 
 use std::collections::HashSet;
 
 pub struct PressedKeys(pub HashSet<Key>);
-
-pub struct CameraPosition {
-    pub x: f32,
-    pub y: f32,
-}
-
-impl CameraPosition {
-    pub fn new(x: f32, y: f32) -> CameraPosition {
-        CameraPosition { x: x, y: y }
-    }
-}
+pub struct CameraPosition(pub Vector2<f32>);

--- a/src/ecs/system/camera_input_system.rs
+++ b/src/ecs/system/camera_input_system.rs
@@ -48,18 +48,18 @@ impl specs::System<()> for CameraInputSystem {
         for (velocity, _camera) in (&mut velocities, &cameras).iter() {
             let pressed_keys = &pressed_keys.0;
             if pressed_keys.contains(&Key::Up) {
-                velocity.y = -CAMERA_SPEED;
+                velocity.velocity.y = -CAMERA_SPEED;
             } else if pressed_keys.contains(&Key::Down) {
-                velocity.y = CAMERA_SPEED;
+                velocity.velocity.y = CAMERA_SPEED;
             } else {
-                velocity.y = 0f32;
+                velocity.velocity.y = 0f32;
             }
             if pressed_keys.contains(&Key::Left) {
-                velocity.x = -CAMERA_SPEED;
+                velocity.velocity.x = -CAMERA_SPEED;
             } else if pressed_keys.contains(&Key::Right) {
-                velocity.x = CAMERA_SPEED;
+                velocity.velocity.x = CAMERA_SPEED;
             } else {
-                velocity.x = 0f32;
+                velocity.velocity.x = 0f32;
             }
         }
     }

--- a/src/ecs/system/camera_position_system.rs
+++ b/src/ecs/system/camera_position_system.rs
@@ -23,6 +23,7 @@ use ecs::{TransformComponent, CameraComponent};
 use ecs::resource::CameraPosition;
 
 use specs::{self, Join};
+use types::{Vector2};
 
 pub struct CameraPositionSystem;
 
@@ -42,7 +43,7 @@ impl specs::System<()> for CameraPositionSystem {
 
         // Grab camera position from first encountered enabled camera
         for (transform, _camera) in (&transforms, &cameras).iter() {
-            *cam_pos_resource = CameraPosition::new(transform.x, transform.y);
+            *cam_pos_resource = CameraPosition(Vector2::new(transform.position.x, transform.position.y));
             break;
         }
     }

--- a/src/ecs/system/grid_system.rs
+++ b/src/ecs/system/grid_system.rs
@@ -45,7 +45,7 @@ impl specs::System<()> for GridSystem {
 
         let mut grid = self.grid.write().unwrap();
         for (entity, transform) in (&entities, &transforms).iter() {
-            grid.update_entity(entity.get_id(), (transform.x as i32, transform.y as i32));
+            grid.update_entity(entity.get_id(), (transform.position.x as i32, transform.position.y as i32));
         }
     }
 }

--- a/src/ecs/system/velocity_system.rs
+++ b/src/ecs/system/velocity_system.rs
@@ -38,9 +38,9 @@ impl specs::System<()> for VelocitySystem {
 
         for (transform, velocity) in (&mut transforms, &velocities).iter() {
             // TODO: Factor in time delta
-            (*transform).x += velocity.x;
-            (*transform).y += velocity.y;
-            (*transform).z += velocity.z;
+            (*transform).position.x += velocity.velocity.x;
+            (*transform).position.y += velocity.velocity.y;
+            (*transform).position.z += velocity.velocity.z;
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,8 +42,8 @@ mod partition;
 
 use terrain::TerrainBlender;
 use terrain::TerrainRenderer;
-use types::{Point, Rect};
-use ecs::resource::{CameraPosition, PressedKeys};
+use types::{Point, Rect, Vector2};
+use ecs::resource::{PressedKeys, CameraPosition};
 use ecs::render_system::UnitRenderSystem;
 
 use std::process;
@@ -120,7 +120,7 @@ fn main() {
     let mut world_planner = ecs::create_world_planner();
 
     // Setup the camera
-    world_planner.mut_world().add_resource(CameraPosition::new(0., 0.));
+    world_planner.mut_world().add_resource(CameraPosition(Vector2::new(0f32, 0f32)));
     world_planner.mut_world().create_now()
         // Temporary hardcoded camera offset
         .with(ecs::TransformComponent::new(126f32 * tile_half_width as f32,
@@ -182,7 +182,7 @@ fn main() {
             let camera_pos = world_planner.mut_world().read_resource::<CameraPosition>();
             media.borrow_mut()
                 .renderer()
-                .set_camera_position(&Point::new(camera_pos.x as i32, camera_pos.y as i32));
+                .set_camera_position(&Point::new(camera_pos.0.x as i32, camera_pos.0.y as i32));
         }
 
         // TODO: Render only the visible portion of the map


### PR DESCRIPTION
I decided to use `Vector` as fields instead of turning the whole component into a `Vector` because this way we can still `impl specs::Component` on the component, otherwise rustc will throw [E0117](https://doc.rust-lang.org/error-index.html#E0117)
Closes #18
