### PR TITLE
slp_viewer: Use clap::value_t! instead of str::parse::<u32>

### DIFF
--- a/tools/slp_viewer/src/main.rs
+++ b/tools/slp_viewer/src/main.rs
@@ -24,6 +24,8 @@ extern crate open_aoe_slp as slp;
 extern crate open_aoe_palette as palette;
 
 extern crate minifb;
+
+#[macro_use(value_t)]
 extern crate clap;
 
 use clap::{App, Arg};
@@ -113,7 +115,7 @@ fn main() {
             .index(1))
         .get_matches();
 
-    let slp_id = matches.value_of("SLP").unwrap().parse::<u32>().expect("valid SLP ID");
+    let slp_id = value_t!(matches, "SLP", u32).expect("valid SLP ID");
     let drs_name = matches.value_of("DRS").unwrap_or("game/data/graphics.drs");
     let interfac_name = matches.value_of("INTERFAC").unwrap_or("game/data/interfac.drs");
     let mut player_index = matches.value_of("PLAYER")


### PR DESCRIPTION
May want `value_t_or_exit!` instead.
If so, let me know and I will update this.

https://docs.rs/clap/2.17.1/clap/macro.value_t_or_exit.html